### PR TITLE
[ReHydrate] Fix up some dependencies for use with dependency-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,23 +6,28 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "bsb -w",
-    "build": "webpack ./lib/js/examples/pure/index.js --output-filename ./finalOutput/out.js"
+    "postinstall": "eval $(dependencyEnv) && nopam && echo 'execute npm start'",
+    "build": "webpack ./lib/js/examples/pure/index.js --output-filename ./finalOutput/out.js",
+    "top": "eval $(dependencyEnv) && rtop",
+    "env": "eval $(dependencyEnv) && env"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "bs-platform": "^1.3.3",
-    "reason": "https://github.com/facebook/Reason.git",
-    "webpack": "^1.14.0",
-    "react": "^15.0.0",
-    "react-dom": "^15.0.0"
   },
   "peerDependencies": {
     "react": "^15.0.0",
     "react-dom": "^15.0.0"
   },
   "dependencies": {
-    "reason-js": "0.0.3"
+    "bs-platform": "^1.3.3",
+    "reason": "https://github.com/facebook/Reason.git",
+    "webpack": "^1.14.0",
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0",
+    "reason-js": "0.0.3",
+    "nopam": "https://github.com/reasonml/nopam.git",
+    "dependency-env": "*"
   }
 }

--- a/secret_readme.md
+++ b/secret_readme.md
@@ -17,3 +17,30 @@ npm run build
 
 ## Usage
 See the `examples/` folder.
+
+
+## Known Issues:
+
+`bsb` currently builds a `.merlin` file that doesn't quite work right for some reason.
+Comment it out before editing, and it won't fail, but you won't get any type checking by merlin.
+To fix the `.merlin` file,  make it look something like this (by hand).
+
+
+```
+####{BSB GENERATED: NO EDIT
+S /absolute/path/to/rehydrate/node_modules/bs-platform/bin/../lib/ocaml
+B /absolute/path/to/rehydrate/node_modules/bs-platform/bin/../lib/ocaml
+FLG -ppx bsppx.exe
+FLG -ppx reactjs_jsx_ppx
+
+S examples
+B lib/bs/examples
+
+S examples/pure
+B lib/bs/examples/pure
+
+S src
+B lib/bs/src
+
+####BSB GENERATED: NO EDIT}
+```


### PR DESCRIPTION
Summary: This is so that I can start my editor via `npm run env -- vim`.
Also, added note in readme explaining why/how merlin doesn't work with
this yet.

Test Plan:

Reviewers:

CC: