### PR TITLE
Api refactor

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -6,7 +6,7 @@
   "name" : "ReactRePureExample",
   "version": "0.0.0",
   "ppx-flags": ["reason/reactjs_jsx_ppx.native"],
-  "bsc-flags": ["-bs-sort-imports", "-bin-annot"],
+  "bsc-flags": ["-w -40 -bs-sort-imports", "-bin-annot"],
   "refmt": "reason/refmt_impl.native",
   "generate-merlin": true,
   "bs-dependencies": ["reason-js"],

--- a/examples/pure/index.re
+++ b/examples/pure/index.re
@@ -1,3 +1,4 @@
 Js.log "Do you see this message? If you do, then things should work!";
 
+
 ReactDOMRe.render <Page /> (ReasonJs.Document.getElementById "index");

--- a/examples/pure/lifecycleTester.re
+++ b/examples/pure/lifecycleTester.re
@@ -1,31 +1,28 @@
 /**
  * Page component.
  */
-open ReactRe;
-
-type props = {incrOnDidMount: bool, initialCount: int, incr: int};
-
-include
-  ReactRe.CreateComponent {
-    include ReactRe.Component;
-    type nonrec props = props;
-    type state = {clicks: int};
-    let name = "LifecycleTester";
-    let getInitialState props => {clicks: props.initialCount};
-    let handleClick event {props, state} => Some {clicks: state.clicks + props.incr};
-    let componentDidMount {props, state} => {
-      print_string "IN MOUNT";
-      print_newline ();
-      props.incrOnDidMount ? Some {...state, clicks: state.clicks + props.incr} : None
-    };
-    let render {state, updater} =>
-      <div>
-        <button onClick=(updater handleClick)>
-          (ReactRe.toElement ("Clicked " ^ string_of_int state.clicks ^ " time(s)"))
-        </button>
-        <Logo message="Hello!" />
-      </div>;
+module LifecycleTester = {
+  include ReactRe.Component;
+  type props = {incrOnDidMount: bool, initialCount: int, incr: int};
+  type state = {clicks: int};
+  let name = "LifecycleTester";
+  let getInitialState props => {clicks: props.initialCount};
+  let handleClick event {props, state} => Some {clicks: state.clicks + props.incr};
+  let componentDidMount {props, state} => {
+    print_string "IN MOUNT";
+    print_newline ();
+    props.incrOnDidMount ? Some {clicks: state.clicks + props.incr} : None
   };
+  let render {state, updater} =>
+    <div>
+      <button onClick=(updater handleClick)>
+        (ReactRe.toElement ("Clicked " ^ string_of_int state.clicks ^ " time(s)"))
+      </button>
+      <Logo message="Hello!" />
+    </div>;
+};
+
+include ReactRe.CreateComponent LifecycleTester;
 
 let createElement ::incrOnDidMount=false ::incr=0 ::initialCount=0 children =>
   wrapProps {incrOnDidMount, initialCount, incr} children;

--- a/examples/pure/lifecycleTester.re
+++ b/examples/pure/lifecycleTester.re
@@ -1,0 +1,31 @@
+/**
+ * Page component.
+ */
+open ReactRe;
+
+type props = {incrOnDidMount: bool, initialCount: int, incr: int};
+
+include
+  ReactRe.CreateComponent {
+    include ReactRe.Component;
+    type nonrec props = props;
+    type state = {clicks: int};
+    let name = "LifecycleTester";
+    let getInitialState props => {clicks: props.initialCount};
+    let handleClick event {props, state} => Some {clicks: state.clicks + props.incr};
+    let componentDidMount {props, state} => {
+      print_string "IN MOUNT";
+      print_newline ();
+      props.incrOnDidMount ? Some {...state, clicks: state.clicks + props.incr} : None
+    };
+    let render {state, updater} =>
+      <div>
+        <button onClick=(updater handleClick)>
+          (ReactRe.toElement ("Clicked " ^ string_of_int state.clicks ^ " time(s)"))
+        </button>
+        <Logo message="Hello!" />
+      </div>;
+  };
+
+let createElement ::incrOnDidMount=false ::incr=0 ::initialCount=0 children =>
+  wrapProps {incrOnDidMount, initialCount, incr} children;

--- a/examples/pure/logo.re
+++ b/examples/pure/logo.re
@@ -1,17 +1,14 @@
 /**
  * Logo component.
  */
-open ReactRe;
-
-type logoProps = {message: string};
-
-include ReactRe.CreateComponent {
+module Logo = {
+  type logoProps = {message: string};
   include ReactRe.StatelessComponent;
   type props = logoProps;
   let name = "Logo";
-  let render {props} => <div> (ReactRe.toElement props.message) </div>;
-  /* let createElement = fun wrapProps => (fun ::message children => wrapProps {message: message} children); */
-  let createElement = fun wrapProps => fun ::message children => wrapProps {message: message} children;
+  let render {ReactRe.Component.props: props} => <div> (ReactRe.toElement props.message) </div>;
 };
+
+include ReactRe.CreateComponent Logo;
 
 let createElement ::message children => wrapProps {message: message} children;

--- a/examples/pure/logo.re
+++ b/examples/pure/logo.re
@@ -1,19 +1,17 @@
-include ReactRe.StatelessComponent;
+/**
+ * Logo component.
+ */
+open ReactRe;
 
-type props = {message: string};
+type logoProps = {message: string};
 
-let render {props} => <div> (ReactRe.toElement props.message) </div>;
+include ReactRe.CreateComponent {
+  include ReactRe.StatelessComponent;
+  type props = logoProps;
+  let name = "Logo";
+  let render {props} => <div> (ReactRe.toElement props.message) </div>;
+  /* let createElement = fun wrapProps => (fun ::message children => wrapProps {message: message} children); */
+  let createElement = fun wrapProps => fun ::message children => wrapProps {message: message} children;
+};
 
-/* This part is the secret sauce that briges to Reactjs. It's a bit verbose (but consistentt) right now; We'll
-   find a way to make it shorter in the future. */
-let (comp, wrapProps) =
-  createClass
-    name::"Logo"
-    ::getInstanceVariables
-    ::componentDidMount
-    ::componentWillReceiveProps
-    ::componentDidUpdate
-    ::componentWillUnmount
-    render;
-
-let createElement ::message => wrapProps {message: message};
+let createElement ::message children => wrapProps {message: message} children;

--- a/examples/pure/page.re
+++ b/examples/pure/page.re
@@ -1,32 +1,25 @@
-include ReactRe.Component;
+/**
+ * Page component.
+ */
+open ReactRe;
 
-type props = unit;
-
-type state = {clicks: int};
-
-let getInitialState props => {clicks: 0};
-
-let handleClick event {state} => Some {clicks: state.clicks + 1};
-
-let render {state, updater} =>
-  <div>
-    <button onClick=(updater handleClick)>
-      (ReactRe.toElement ("Clicked " ^ string_of_int state.clicks ^ " time(s)"))
-    </button>
-    <Logo message="Hello!" />
-  </div>;
-
-/* This part is the secret sauce that briges to Reactjs. It's a bit verbose (but consistentt) right now; We'll
-   find a way to make it shorter in the future. */
-let (comp, wrapProps) =
-  createClass
-    name::"Page"
-    ::getInitialState
-    ::getInstanceVariables
-    ::componentDidMount
-    ::componentWillReceiveProps
-    ::componentDidUpdate
-    ::componentWillUnmount
-    render;
+include
+  ReactRe.CreateComponent {
+    include ReactRe.Component;
+    type props = unit;
+    type state = {clicks: int};
+    type jsPropTypes = string;
+    let name = "Page";
+    let getInitialState props => {clicks: 0};
+    let handleClick event {state} => Some {clicks: state.clicks + 2};
+    let render {state, updater} =>
+      <div>
+        <button onClick=(updater handleClick)>
+          (ReactRe.toElement ("Clicked " ^ string_of_int state.clicks ^ " time(s)"))
+        </button>
+        <Logo message="Hello!" />
+        <LifecycleTester incrOnDidMount=true initialCount=10 incr=3 />
+      </div>;
+  };
 
 let createElement children => wrapProps () children;

--- a/examples/pure/page.re
+++ b/examples/pure/page.re
@@ -1,25 +1,24 @@
 /**
  * Page component.
  */
-open ReactRe;
+module Page = {
+  include ReactRe.Component;
+  type props = unit;
+  type state = {clicks: int};
+  type jsPropTypes = string;
+  let name = "Page";
+  let getInitialState props => {clicks: 0};
+  let handleClick event {state} => Some {clicks: state.clicks + 2};
+  let render {state, updater} =>
+    <div>
+      <button onClick=(updater handleClick)>
+        (ReactRe.toElement ("Clicked " ^ string_of_int state.clicks ^ " time(s)"))
+      </button>
+      <Logo message="Hello!" />
+      <LifecycleTester incrOnDidMount=true initialCount=10 incr=3 />
+    </div>;
+};
 
-include
-  ReactRe.CreateComponent {
-    include ReactRe.Component;
-    type props = unit;
-    type state = {clicks: int};
-    type jsPropTypes = string;
-    let name = "Page";
-    let getInitialState props => {clicks: 0};
-    let handleClick event {state} => Some {clicks: state.clicks + 2};
-    let render {state, updater} =>
-      <div>
-        <button onClick=(updater handleClick)>
-          (ReactRe.toElement ("Clicked " ^ string_of_int state.clicks ^ " time(s)"))
-        </button>
-        <Logo message="Hello!" />
-        <LifecycleTester incrOnDidMount=true initialCount=10 incr=3 />
-      </div>;
-  };
+include ReactRe.CreateComponent Page;
 
 let createElement children => wrapProps () children;

--- a/src/reactRe.re
+++ b/src/reactRe.re
@@ -142,481 +142,341 @@ let rec findFirstCallback callbacks callback =>
   | [_, ...rest] => findFirstCallback rest callback
   | [] => None
   };
+type jsState 'state = Js.t {. mlState : 'state};
+
+type jsComponentThis 'state 'props =
+  Js.t {. state : jsState 'state, props : Obj.t, setState : (jsState 'state => unit) [@bs.meth]};
+
+type componentBag 'state 'props 'instanceVariables = {
+  state: 'state,
+  props: 'props,
+  updater:
+    'dataPassedToHandler .
+    ('dataPassedToHandler => componentBag 'state 'props 'instanceVariables => option 'state) =>
+    'dataPassedToHandler =>
+    unit,
+
+  refSetter: (reactRef => componentBag 'state 'props 'instanceVariables => unit) => reactRef => unit,
+  instanceVariables: 'instanceVariables
+};
 
 module StatelessComponent = {
-  type componentBag 'props 'instanceVariables = {
-    props: 'props,
-    updater:
-      'dataPassedToHandler .
-      ('dataPassedToHandler => componentBag 'props 'instanceVariables => unit) =>
-      'dataPassedToHandler =>
-      unit,
-
-    refSetter: (reactRef => componentBag 'props 'instanceVariables => unit) => reactRef => unit,
-    instanceVariables: 'instanceVariables
-  };
+  type state = unit;
+  type instanceVariables = unit;
   type jsComponentThis 'props = Js.t {. props : Obj.t};
   let getInstanceVariables () => ();
-  let componentDidMount _ => ();
+  let getInitialState _ => ();
+  let componentDidMount _ => None;
   /* let shouldComponentUpdate _ _ => true; */
-  let componentDidUpdate _ _ => ();
-  let componentWillReceiveProps _ _ => ();
+  let componentDidUpdate _ _ _ => None;
+  let componentWillReceiveProps _ _ => None;
   let componentWillUnmount _ => ();
-  let createClass
-      (type props)
-      (type jsPropsType)
-      (type instanceVariables)
-      ::name
-      getInstanceVariables::(getInstanceVariables: unit => instanceVariables)
-      componentDidMount::(componentDidMount: componentBag props instanceVariables => unit)
-      componentWillReceiveProps::(
-        componentWillReceiveProps: props => componentBag props instanceVariables => unit
-      )
-      componentDidUpdate::(
-        componentDidUpdate: props => componentBag props instanceVariables => unit
-      )
-      componentWillUnmount::(componentWillUnmount: componentBag props instanceVariables => unit)
-      jsPropsToReasonProps::(jsPropsToReasonProps: option (jsPropsType => props))=?
-      (render: componentBag props instanceVariables => reactElement) => {
-    let convertPropsIfTheyreFromJs props => {
-      let props = Obj.magic props;
-      switch (Js.Undefined.to_opt props##reasonProps, jsPropsToReasonProps) {
-      | (Some props, _) => props
-      /* TODO: annotate with BS to avoid curry overhead */
-      | (None, Some toReasonProps) => toReasonProps props
-      | (None, None) =>
-        raise (
-          Invalid_argument (
-            "A JS component called the Reason component " ^
-            name ^ " which didn't implement the JS->Reason React props conversion"
-          )
-        )
-      }
-    };
-    let comp =
-      createClass (
-        {
-          val displayName = name;
-          val mutable instanceVariables = None;
-          val mutable memoizedUpdaterCallbacks = [];
-          val mutable memoizedRefCallbacks = [];
-          pri componentWillMount () => this##instanceVariables#=(Some (getInstanceVariables ()));
-          pri componentDidMount () => {
-            let that: jsComponentThis props = [%bs.raw "this"];
-            let instanceVariables =
-              switch this##instanceVariables {
-              | None =>
-                raise (
-                  Invalid_argument "ReactRe stateless component: instanceVariables somehow isn't initialized."
-                )
-              | Some s => s
-              };
-            componentDidMount {
-              props: convertPropsIfTheyreFromJs that##props,
-              instanceVariables,
-              updater: Obj.magic this##updaterMethod,
-              refSetter: Obj.magic this##refSetterMethod
-            }
-          };
-          pri componentDidUpdate prevProps _ => {
-            let that: jsComponentThis props = [%bs.raw "this"];
-            let instanceVariables =
-              switch this##instanceVariables {
-              | None =>
-                raise (
-                  Invalid_argument "ReactRe stateless component: instanceVariables somehow isn't initialized."
-                )
-              | Some s => s
-              };
-            componentDidUpdate
-              (convertPropsIfTheyreFromJs prevProps)
-              {
-                props: convertPropsIfTheyreFromJs that##props,
-                instanceVariables,
-                updater: Obj.magic this##updaterMethod,
-                refSetter: Obj.magic this##refSetterMethod
-              }
-          };
-          pri componentWillReceiveProps nextProps => {
-            let that: jsComponentThis props = [%bs.raw "this"];
-            let instanceVariables =
-              switch this##instanceVariables {
-              | None =>
-                raise (
-                  Invalid_argument "ReactRe stateless component: instanceVariables somehow isn't initialized."
-                )
-              | Some s => s
-              };
-            componentWillReceiveProps
-              (convertPropsIfTheyreFromJs nextProps)
-              {
-                props: convertPropsIfTheyreFromJs that##props,
-                instanceVariables,
-                updater: Obj.magic this##updaterMethod,
-                refSetter: Obj.magic this##refSetterMethod
-              }
-          };
-          pri componentWillUnmount () => {
-            let that: jsComponentThis props = [%bs.raw "this"];
-            let instanceVariables =
-              switch this##instanceVariables {
-              | None =>
-                raise (
-                  Invalid_argument "ReactRe stateless component: instanceVariables somehow isn't initialized."
-                )
-              | Some s => s
-              };
-            componentWillUnmount {
-              props: convertPropsIfTheyreFromJs that##props,
-              instanceVariables,
-              updater: Obj.magic this##updaterMethod,
-              refSetter: Obj.magic this##refSetterMethod
-            }
-          };
-          pri updaterMethod callback =>
-            switch (findFirstCallback this##memoizedUpdaterCallbacks callback) {
-            | Some memoized => memoized
-            | None =>
-              let that: jsComponentThis props = [%bs.raw "this"];
-              let memoizedCallback event => {
-                let instanceVariables =
-                  switch this##instanceVariables {
-                  | None =>
-                    raise (
-                      Invalid_argument "ReactRe stateless component: instanceVariables somehow isn't initialized."
-                    )
-                  | Some s => s
-                  };
-                callback
-                  event
-                  {
-                    props: convertPropsIfTheyreFromJs that##props,
-                    instanceVariables,
-                    updater: Obj.magic this##updaterMethod,
-                    refSetter: Obj.magic this##refSetterMethod
-                  }
-              };
-              this##memoizedUpdaterCallbacks#=[
-                                                (callback, memoizedCallback),
-                                                ...this##memoizedUpdaterCallbacks
-                                              ];
-              memoizedCallback
-            };
-          pri refSetterMethod callback =>
-            switch (findFirstCallback this##memoizedRefCallbacks callback) {
-            | Some memoized => memoized
-            | None =>
-              let that: jsComponentThis props = [%bs.raw "this"];
-              let memoizedCallback (theRef: reactRef) => {
-                let instanceVariables =
-                  switch this##instanceVariables {
-                  | None =>
-                    raise (
-                      Invalid_argument "ReactRe stateless component: instanceVariables somehow isn't initialized."
-                    )
-                  | Some s => s
-                  };
-                callback
-                  theRef
-                  {
-                    props: convertPropsIfTheyreFromJs that##props,
-                    instanceVariables,
-                    updater: Obj.magic this##updaterMethod,
-                    refSetter: Obj.magic this##refSetterMethod
-                  }
-              };
-              this##memoizedRefCallbacks#=[
-                                            (callback, memoizedCallback),
-                                            ...this##memoizedRefCallbacks
-                                          ];
-              memoizedCallback
-            };
-          pri render () => {
-            let that: jsComponentThis props = [%bs.raw "this"];
-            let instanceVariables =
-              switch this##instanceVariables {
-              | None =>
-                raise (
-                  Invalid_argument "ReactRe stateless component: instanceVariables somehow isn't initialized."
-                )
-              | Some s => s
-              };
-            render {
-              props: convertPropsIfTheyreFromJs that##props,
-              instanceVariables,
-              updater: Obj.magic this##updaterMethod,
-              refSetter: Obj.magic this##refSetterMethod
-            }
-          }
-        }
-        [@bs]
-      );
-    /* We wrap the props for reason->reason components, as a marker that "these props were passed from another
-       reason component" */
-    (comp, wrapPropsInternal ::comp)
-  };
+  let jsPropsToReasonProps = None;
 };
 
 module Component = {
-  type componentBag 'state 'props 'instanceVariables = {
-    state: 'state,
-    props: 'props,
-    updater:
-      'dataPassedToHandler .
-      ('dataPassedToHandler => componentBag 'state 'props 'instanceVariables => option 'state) =>
-      'dataPassedToHandler =>
-      unit,
-
-    refSetter:
-      (reactRef => componentBag 'state 'props 'instanceVariables => unit) => reactRef => unit,
-    instanceVariables: 'instanceVariables
-  };
-  type jsState 'state = Js.t {. mlState : 'state};
-  type jsComponentThis 'state 'props =
-    Js.t {. state : jsState 'state, props : Obj.t, setState : (jsState 'state => unit) [@bs.meth]};
+  type instanceVariables = unit;
+  type nonrec jsComponentThis 'props = jsComponentThis unit 'props;
   let getInstanceVariables () => ();
   let componentDidMount _ => None;
   /* let shouldComponentUpdate _ _ => true; */
   let componentDidUpdate _ _ _ => None;
   let componentWillReceiveProps _ _ => None;
   let componentWillUnmount _ => ();
-  let createClass
-      (type state)
-      (type props)
-      (type jsPropsType)
-      (type instanceVariables)
-      ::name
-      getInstanceVariables::(getInstanceVariables: unit => instanceVariables)
-      getInitialState::(getInitialState: props => state)
-      componentDidMount::(
-        componentDidMount: componentBag state props instanceVariables => option state
-      )
-      componentWillReceiveProps::(
-        componentWillReceiveProps:
-          props => componentBag state props instanceVariables => option state
-      )
-      componentDidUpdate::(
-        componentDidUpdate:
-          props => state => componentBag state props instanceVariables => option state
-      )
-      componentWillUnmount::(
-        componentWillUnmount: componentBag state props instanceVariables => unit
-      )
-      jsPropsToReasonProps::(jsPropsToReasonProps: option (jsPropsType => props))=?
-      (render: componentBag state props instanceVariables => reactElement) => {
-    let convertPropsIfTheyreFromJs props => {
-      let props = Obj.magic props;
-      switch (Js.Undefined.to_opt props##reasonProps, jsPropsToReasonProps) {
-      | (Some props, _) => props
-      /* TODO: annotate with BS to avoid curry overhead */
-      | (None, Some toReasonProps) => toReasonProps props
-      | (None, None) =>
-        raise (
-          Invalid_argument (
-            "A JS component called the Reason component " ^
-            name ^ " which didn't implement the JS->Reason React props conversion"
-          )
+  let jsPropsToReasonProps = None;
+};
+
+
+/**
+ * Ironically, this mixin doesn't include type instanceVariables.
+ */
+module ComponentWithInstanceVariable = {
+  type nonrec jsComponentThis 'props = jsComponentThis unit 'props;
+  let getInstanceVariables () => ();
+  let componentDidMount _ => None;
+  /* let shouldComponentUpdate _ _ => true; */
+  let componentDidUpdate _ _ _ => None;
+  let componentWillReceiveProps _ _ => None;
+  let componentWillUnmount _ => ();
+  let jsPropsToReasonProps = None;
+};
+
+module type CompleteComponentSpec = {
+  let name: string;
+  type props;
+  type state;
+  type instanceVariables;
+  let getInstanceVariables: unit => instanceVariables;
+  let getInitialState: props => state;
+
+  /**
+   * TODO: Preallocate a "returnNone", and then at runtime check for reference
+   * equality to this function and avoid even invoking it.
+   */
+  let componentDidMount: componentBag state props instanceVariables => option state;
+  let componentWillReceiveProps: props => componentBag state props instanceVariables => option state;
+  let componentDidUpdate:
+    props => state => componentBag state props instanceVariables => option state;
+  let componentWillUnmount: componentBag state props instanceVariables => unit;
+  let jsPropsToReasonProps: option (Js.t 'a => props);
+  let render: componentBag state props instanceVariables => reactElement;
+};
+
+module type ReactComponent = {
+  type props_;
+  let comp: reactClass;
+  let wrapProps: props_ => list reactElement => reactElement;
+};
+
+module CreateComponent
+       (CompleteComponentSpec: CompleteComponentSpec)
+       :(ReactComponent with type props_ = CompleteComponentSpec.props) => {
+  type props_ = CompleteComponentSpec.props;
+  /* This part is the secret sauce that briges to Reactjs. It's a bit verbose (but consistentt) right now; We'll
+     find a way to make it shorter in the future. */
+  let convertPropsIfTheyreFromJs props => {
+    let props = Obj.magic props;
+    switch (Js.Undefined.to_opt props##reasonProps, CompleteComponentSpec.jsPropsToReasonProps) {
+    | (Some props, _) => props
+    /* TODO: annotate with BS to avoid curry overhead */
+    | (None, Some toReasonProps) => toReasonProps props
+    | (None, None) =>
+      raise (
+        Invalid_argument (
+          "A JS component called the Reason component " ^
+          CompleteComponentSpec.name ^ " which didn't implement the JS->Reason React props conversion"
         )
-      }
-    };
-    let comp =
-      createClass (
-        {
-          val displayName = name;
-          val mutable instanceVariables = None;
-          val mutable memoizedUpdaterCallbacks = [];
-          val mutable memoizedRefCallbacks = [];
-          pri getInitialState () :jsState state => {
-            let that: jsComponentThis state props = [%bs.raw "this"];
-            let props = convertPropsIfTheyreFromJs that##props;
-            let state = getInitialState props;
-            this##instanceVariables#=(Some (getInstanceVariables ()));
-            {"mlState": state}
-          };
-          pri componentDidMount () => {
-            let that: jsComponentThis state props = [%bs.raw "this"];
-            let instanceVariables =
-              switch this##instanceVariables {
-              | None =>
-                raise (
-                  Invalid_argument "ReactRe stateful component: instanceVariables somehow isn't initialized."
-                )
-              | Some s => s
-              };
-            let currState = that##state##mlState;
-            let newState =
-              componentDidMount {
+      )
+    }
+  };
+  let comp =
+    createClass (
+      {
+        val displayName = CompleteComponentSpec.name;
+        val mutable instanceVariables = None;
+        val mutable memoizedUpdaterCallbacks = [];
+        val mutable memoizedRefCallbacks = [];
+        pub getInitialState () :jsState CompleteComponentSpec.state => {
+          let that: jsComponentThis CompleteComponentSpec.state CompleteComponentSpec.props = [%bs.raw
+            "this"
+          ];
+          let props = convertPropsIfTheyreFromJs that##props;
+          let state = CompleteComponentSpec.getInitialState props;
+          this##instanceVariables#=(Some (CompleteComponentSpec.getInstanceVariables ()));
+          {"mlState": state}
+        };
+        pub componentDidMount () => {
+          let that: jsComponentThis CompleteComponentSpec.state CompleteComponentSpec.props = [%bs.raw
+            "this"
+          ];
+          let instanceVariables =
+            switch this##instanceVariables {
+            | None =>
+              raise (
+                Invalid_argument "ReactRe stateful component: instanceVariables somehow isn't initialized."
+              )
+            | Some s => s
+            };
+          let currState = that##state##mlState;
+          let newState =
+            CompleteComponentSpec.componentDidMount {
+              props: convertPropsIfTheyreFromJs that##props,
+              state: currState,
+              instanceVariables,
+              updater: Obj.magic this##updaterMethod,
+              refSetter: Obj.magic this##refSetterMethod
+            };
+          switch newState {
+          | None => ()
+          | Some state => that##setState {"mlState": state}
+          }
+        };
+        pub componentDidUpdate prevProps prevState => {
+          let that: jsComponentThis CompleteComponentSpec.state CompleteComponentSpec.props = [%bs.raw
+            "this"
+          ];
+          let instanceVariables =
+            switch this##instanceVariables {
+            | None =>
+              raise (
+                Invalid_argument "ReactRe stateful component: instanceVariables somehow isn't initialized."
+              )
+            | Some s => s
+            };
+          let currState = that##state##mlState;
+          let newState =
+            CompleteComponentSpec.componentDidUpdate
+              (convertPropsIfTheyreFromJs prevProps)
+              prevState##mlState
+              {
                 props: convertPropsIfTheyreFromJs that##props,
                 state: currState,
                 instanceVariables,
                 updater: Obj.magic this##updaterMethod,
                 refSetter: Obj.magic this##refSetterMethod
               };
-            switch newState {
-            | None => ()
-            | Some state => that##setState {"mlState": state}
-            }
-          };
-          pri componentDidUpdate prevProps prevState => {
-            let that: jsComponentThis state props = [%bs.raw "this"];
-            let instanceVariables =
-              switch this##instanceVariables {
-              | None =>
-                raise (
-                  Invalid_argument "ReactRe stateful component: instanceVariables somehow isn't initialized."
-                )
-              | Some s => s
-              };
-            let currState = that##state##mlState;
-            let newState =
-              componentDidUpdate
-                (convertPropsIfTheyreFromJs prevProps)
-                prevState##mlState
-                {
-                  props: convertPropsIfTheyreFromJs that##props,
-                  state: currState,
-                  instanceVariables,
-                  updater: Obj.magic this##updaterMethod,
-                  refSetter: Obj.magic this##refSetterMethod
-                };
-            switch newState {
-            | None => ()
-            | Some state => that##setState {"mlState": state}
-            }
-          };
-          pri componentWillReceiveProps nextProps => {
-            let that: jsComponentThis state props = [%bs.raw "this"];
-            let instanceVariables =
-              switch this##instanceVariables {
-              | None =>
-                raise (
-                  Invalid_argument "ReactRe stateful component: instanceVariables somehow isn't initialized."
-                )
-              | Some s => s
-              };
-            let currState = that##state##mlState;
-            let newState =
-              componentWillReceiveProps
-                (convertPropsIfTheyreFromJs nextProps)
-                {
-                  props: convertPropsIfTheyreFromJs that##props,
-                  state: currState,
-                  instanceVariables,
-                  updater: Obj.magic this##updaterMethod,
-                  refSetter: Obj.magic this##refSetterMethod
-                };
-            switch newState {
-            | None => ()
-            | Some state => that##setState {"mlState": state}
-            }
-          };
-          pri componentWillUnmount () => {
-            let that: jsComponentThis state props = [%bs.raw "this"];
-            let instanceVariables =
-              switch this##instanceVariables {
-              | None =>
-                raise (
-                  Invalid_argument "ReactRe stateful component: instanceVariables somehow isn't initialized."
-                )
-              | Some s => s
-              };
-            let currState = that##state##mlState;
-            componentWillUnmount {
-              props: convertPropsIfTheyreFromJs that##props,
-              state: currState,
-              instanceVariables,
-              updater: Obj.magic this##updaterMethod,
-              refSetter: Obj.magic this##refSetterMethod
-            }
-          };
-          pri refSetterMethod callback =>
-            switch (findFirstCallback this##memoizedRefCallbacks callback) {
-            | Some memoized => memoized
+          switch newState {
+          | None => ()
+          | Some state => that##setState {"mlState": state}
+          }
+        };
+        pub componentWillReceiveProps nextProps => {
+          let that: jsComponentThis CompleteComponentSpec.state CompleteComponentSpec.props = [%bs.raw
+            "this"
+          ];
+          let instanceVariables =
+            switch this##instanceVariables {
             | None =>
-              let that: jsComponentThis state props = [%bs.raw "this"];
-              let memoizedCallback (theRef: reactRef) => {
-                let instanceVariables =
-                  switch this##instanceVariables {
-                  | None =>
-                    raise (
-                      Invalid_argument "ReactRe stateless component: instanceVariables somehow isn't initialized."
-                    )
-                  | Some s => s
-                  };
-                let currState = that##state##mlState;
+              raise (
+                Invalid_argument "ReactRe stateful component: instanceVariables somehow isn't initialized."
+              )
+            | Some s => s
+            };
+          let currState = that##state##mlState;
+          let newState =
+            CompleteComponentSpec.componentWillReceiveProps
+              (convertPropsIfTheyreFromJs nextProps)
+              {
+                props: convertPropsIfTheyreFromJs that##props,
+                state: currState,
+                instanceVariables,
+                updater: Obj.magic this##updaterMethod,
+                refSetter: Obj.magic this##refSetterMethod
+              };
+          switch newState {
+          | None => ()
+          | Some state => that##setState {"mlState": state}
+          }
+        };
+        pub componentWillUnmount () => {
+          let that: jsComponentThis CompleteComponentSpec.state CompleteComponentSpec.props = [%bs.raw
+            "this"
+          ];
+          let instanceVariables =
+            switch this##instanceVariables {
+            | None =>
+              raise (
+                Invalid_argument "ReactRe stateful component: instanceVariables somehow isn't initialized."
+              )
+            | Some s => s
+            };
+          let currState = that##state##mlState;
+          CompleteComponentSpec.componentWillUnmount {
+            props: convertPropsIfTheyreFromJs that##props,
+            state: currState,
+            instanceVariables,
+            updater: Obj.magic this##updaterMethod,
+            refSetter: Obj.magic this##refSetterMethod
+          }
+        };
+        pub refSetterMethod callback => {
+          let results = findFirstCallback this##memoizedRefCallbacks callback;
+          if results !== [] {
+            let (cb, memoized) = List.nth results 0;
+            memoized;
+          } else {
+            let that: jsComponentThis CompleteComponentSpec.state CompleteComponentSpec.props = [%bs.raw
+              "this"
+            ];
+            let memoizedCallback (theRef: reactRef) => {
+              let instanceVariables =
+                switch this##instanceVariables {
+                | None =>
+                  raise (
+                    Invalid_argument "ReactRe stateless component: instanceVariables somehow isn't initialized."
+                  )
+                | Some s => s
+                };
+              let currState = that##state##mlState;
+              callback
+                theRef
+                {
+                  props: convertPropsIfTheyreFromJs that##props,
+                  state: currState,
+                  instanceVariables,
+                  updater: Obj.magic this##updaterMethod,
+                  refSetter: Obj.magic this##refSetterMethod
+                }
+            };
+            this##memoizedRefCallbacks#=[(callback, memoizedCallback), ...this##memoizedRefCallbacks];
+            memoizedCallback
+          };
+        };
+        pub updaterMethod callback =>
+          let results = findFirstCallback this##memoizedUpdaterCallbacks callback;
+          if (results !== []) {
+              let (cb, memoized) = List.nth results 0;
+              memoized;
+          } else {
+            let that: jsComponentThis CompleteComponentSpec.state CompleteComponentSpec.props = [%bs.raw
+              "this"
+            ];
+            let memoizedCallback event => {
+              let instanceVariables =
+                switch this##instanceVariables {
+                | None =>
+                  raise (
+                    Invalid_argument "ReactRe stateful component: instanceVariables somehow isn't initialized."
+                  )
+                | Some s => s
+                };
+              let currState = that##state##mlState;
+              let newState =
                 callback
-                  theRef
+                  event
                   {
                     props: convertPropsIfTheyreFromJs that##props,
                     state: currState,
                     instanceVariables,
                     updater: Obj.magic this##updaterMethod,
                     refSetter: Obj.magic this##refSetterMethod
-                  }
-              };
-              this##memoizedRefCallbacks#=[
-                                            (callback, memoizedCallback),
-                                            ...this##memoizedRefCallbacks
-                                          ];
-              memoizedCallback
-            };
-          pri updaterMethod callback =>
-            switch (findFirstCallback this##memoizedUpdaterCallbacks callback) {
-            | Some memoized => memoized
-            | None =>
-              let that: jsComponentThis state props = [%bs.raw "this"];
-              let memoizedCallback event => {
-                let instanceVariables =
-                  switch this##instanceVariables {
-                  | None =>
-                    raise (
-                      Invalid_argument "ReactRe stateful component: instanceVariables somehow isn't initialized."
-                    )
-                  | Some s => s
                   };
-                let currState = that##state##mlState;
-                let newState =
-                  callback
-                    event
-                    {
-                      props: convertPropsIfTheyreFromJs that##props,
-                      state: currState,
-                      instanceVariables,
-                      updater: Obj.magic this##updaterMethod,
-                      refSetter: Obj.magic this##refSetterMethod
-                    };
-                switch newState {
-                | None => ()
-                | Some state => that##setState {"mlState": state}
-                }
-              };
-              this##memoizedUpdaterCallbacks#=[
-                                                (callback, memoizedCallback),
-                                                ...this##memoizedUpdaterCallbacks
-                                              ];
-              memoizedCallback
+              switch newState {
+              | None => ()
+              | Some state => that##setState {"mlState": state}
+              }
             };
-          pri render () => {
-            let that: jsComponentThis state props = [%bs.raw "this"];
-            let instanceVariables =
-              switch this##instanceVariables {
-              | None =>
-                raise (
-                  Invalid_argument "ReactRe stateful component: instanceVariables somehow isn't initialized."
-                )
-              | Some s => s
-              };
-            render {
-              props: convertPropsIfTheyreFromJs that##props,
-              state: that##state##mlState,
-              instanceVariables,
-              updater: Obj.magic this##updaterMethod,
-              refSetter: Obj.magic this##refSetterMethod
-            }
+            this##memoizedUpdaterCallbacks#=[
+                                              (callback, memoizedCallback),
+                                              ...this##memoizedUpdaterCallbacks
+                                            ];
+            memoizedCallback
+          };
+        pub render () => {
+          let that: jsComponentThis CompleteComponentSpec.state CompleteComponentSpec.props = [%bs.raw
+            "this"
+          ];
+          let instanceVariables =
+            switch this##instanceVariables {
+            | None =>
+              raise (
+                Invalid_argument "ReactRe stateful component: instanceVariables somehow isn't initialized."
+              )
+            | Some s => s
+            };
+          CompleteComponentSpec.render {
+            props: convertPropsIfTheyreFromJs that##props,
+            state: that##state##mlState,
+            instanceVariables,
+            updater: Obj.magic this##updaterMethod,
+            refSetter: Obj.magic this##refSetterMethod
           }
         }
-        [@bs]
-      );
-    (comp, wrapPropsInternal ::comp)
-  };
+      }
+      [@bs]
+    );
+  let wrapProps props children => wrapPropsInternal ::comp ref::None key::None ::children props;
 };
+
+let decorate ::key=? ::ref=? children => {
+  /**
+   * TODO: Assert that there's only one.
+   */
+};
+/**
+ * Keys/refs should be placed like this:
+ *
+ * <ReactRe.decorate key="key" ref="ref">
+ *   <MyComponent blah="hi" />;
+ * </ReactRe>
+ */


### PR DESCRIPTION
    [ReHydrate] Massive Refactor. Modular API.

    Summary:
    Cleaned up the API a bit. Now, there's a bit less boiler plate to have
    to repeate yourself with.

    I had to rip out the key/ref API here, but you can add a better one in
    its place:

    The next steps are:

    - Making it so you don't need to open `ReactRe`.
    - Adding back a key/ref API (the component author should never have to
    write boiler plate around key/ref).