### PR TITLE
Don't require stateless components to namespace the props record

### DIFF
--- a/examples/pure/logo.re
+++ b/examples/pure/logo.re
@@ -2,11 +2,10 @@
  * Logo component.
  */
 module Logo = {
-  type logoProps = {message: string};
   include ReactRe.StatelessComponent;
-  type props = logoProps;
+  type props = {message: string};
   let name = "Logo";
-  let render {ReactRe.Component.props: props} => <div> (ReactRe.toElement props.message) </div>;
+  let render {props} => <div> (ReactRe.toElement props.message) </div>;
 };
 
 include ReactRe.CreateComponent Logo;

--- a/src/reactRe.re
+++ b/src/reactRe.re
@@ -140,7 +140,7 @@ type jsState 'state = Js.t {. mlState : 'state};
 type jsComponentThis 'state 'props =
   Js.t {. state : jsState 'state, props : Obj.t, setState : (jsState 'state => unit) [@bs.meth]};
 
-module Component = {
+module ComponentBase = {
   type componentBag 'state 'props 'instanceVariables = {
     state: 'state,
     props: 'props,
@@ -153,6 +153,10 @@ module Component = {
     refSetter: (reactRef => componentBag 'state 'props 'instanceVariables => unit) => reactRef => unit,
     instanceVariables: 'instanceVariables
   };
+};
+
+module Component = {
+  include ComponentBase;
   type instanceVariables = unit;
   type nonrec jsComponentThis 'props = jsComponentThis unit 'props;
   let getInstanceVariables () => ();
@@ -165,6 +169,7 @@ module Component = {
 };
 
 module StatelessComponent = {
+  include ComponentBase;
   type state = unit;
   type instanceVariables = unit;
   type jsComponentThis 'props = Js.t {. props : Obj.t};


### PR DESCRIPTION
I missed this in the original API