### PR TITLE
[ReHydrate] Add back ability to convert from JS props.

### DIFF
--- a/examples/pure/logo.re
+++ b/examples/pure/logo.re
@@ -2,10 +2,17 @@
  * Logo component.
  */
 module Logo = {
-  include ReactRe.StatelessComponent;
+
+  /**
+   * Includes StatelessComponentJs instead of StatelessComponent so that it
+   * can convert from js prop types.
+   */
+  include ReactRe.StatelessComponentJs;
+  type jsPropTypes = Js.t {. message : string};
   type props = {message: string};
   let name = "Logo";
   let render {props} => <div> (ReactRe.toElement props.message) </div>;
+  let jsPropsToReasonProps = Some (fun props => {message: props##message});
 };
 
 include ReactRe.CreateComponent Logo;

--- a/examples/pure/page.re
+++ b/examples/pure/page.re
@@ -5,7 +5,6 @@ module Page = {
   include ReactRe.Component;
   type props = unit;
   type state = {clicks: int};
-  type jsPropTypes = string;
   let name = "Page";
   let getInitialState props => {clicks: 0};
   let handleClick event {state} => Some {clicks: state.clicks + 2};

--- a/src/reactRe.re
+++ b/src/reactRe.re
@@ -157,6 +157,20 @@ module ComponentBase = {
 
 module Component = {
   include ComponentBase;
+  type jsPropTypes = unit;
+  type instanceVariables = unit;
+  type nonrec jsComponentThis 'props = jsComponentThis unit 'props;
+  let getInstanceVariables () => ();
+  let componentDidMount _ => None;
+  /* let shouldComponentUpdate _ _ => true; */
+  let componentDidUpdate _ _ _ => None;
+  let componentWillReceiveProps _ _ => None;
+  let componentWillUnmount _ => ();
+  let jsPropsToReasonProps = None;
+};
+
+module ComponentJs = {
+  include ComponentBase;
   type instanceVariables = unit;
   type nonrec jsComponentThis 'props = jsComponentThis unit 'props;
   let getInstanceVariables () => ();
@@ -169,6 +183,22 @@ module Component = {
 };
 
 module StatelessComponent = {
+  include ComponentBase;
+  type jsPropTypes = unit;
+  type state = unit;
+  type instanceVariables = unit;
+  type jsComponentThis 'props = Js.t {. props : Obj.t};
+  let getInstanceVariables () => ();
+  let getInitialState _ => ();
+  let componentDidMount _ => None;
+  /* let shouldComponentUpdate _ _ => true; */
+  let componentDidUpdate _ _ _ => None;
+  let componentWillReceiveProps _ _ => None;
+  let componentWillUnmount _ => ();
+  let jsPropsToReasonProps = None;
+};
+
+module StatelessComponentJs = {
   include ComponentBase;
   type state = unit;
   type instanceVariables = unit;
@@ -203,6 +233,7 @@ module type CompleteComponentSpec = {
   type props;
   type state;
   type instanceVariables;
+  type jsPropTypes;
   let getInstanceVariables: unit => instanceVariables;
   let getInitialState: props => state;
 
@@ -216,7 +247,7 @@ module type CompleteComponentSpec = {
   let componentDidUpdate:
     props => state => Component.componentBag state props instanceVariables => option state;
   let componentWillUnmount: Component.componentBag state props instanceVariables => unit;
-  let jsPropsToReasonProps: option (Js.t 'a => props);
+  let jsPropsToReasonProps: option (jsPropTypes => props);
   let render: Component.componentBag state props instanceVariables => reactElement;
 };
 


### PR DESCRIPTION
Summary:

I had removed this while moving fast, and now I've added back a way to
bridge to JS components. Instead of `include`ing `ReactRe.Component`,
you include `ReactRe.ComponentJs` (or `StatelessJs` depending), then
declare a `type jsPropTypes = ..`, and define `let jsPropsToReasonProps
= Some (fun jsProps => reasonProps)`.

Test Plan:

Reviewers:

CC: