### PR TITLE
Update package name in bsconfig.json

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -3,7 +3,7 @@
   comma. If this screws with your editor highlighting, please tell us by filing
   an issue! */
 {
-  "name" : "ReactRePureExample",
+  "name" : "rehydrate",
   "version": "0.0.0",
   "ppx-flags": ["reason/reactjs_jsx_ppx.native"],
   "bsc-flags": ["-w -40 -bs-sort-imports", "-bin-annot"],


### PR DESCRIPTION
This package name is used in the 'requires' at the top of JS output. My webpack build was failing because it couldn't resolve the name below:
```
ReactRePureExample/lib/js/src/reactRe
```
Instead of what it should be:
```
rehydrate/lib/js/src/reactRe
```