### PR TITLE
Add support to use as npm dependency

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
 .merlin
 /lib/bs
-/examples

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "postinstall": "rm -rf ./lib && bsb",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "bsb -w",
     "build": "webpack -w"


### PR DESCRIPTION
To be able to have `rehydrate` as `npm` dependency I had to add a `postinstall` script to `package.json`.

An example how to ingrate is over at:  [ReasonReactProject](https://github.com/maicki/ReasonReactProject)

cc #14 