### PR TITLE
Strictify the battlestation

### DIFF
--- a/battleStation.js
+++ b/battleStation.js
@@ -1,3 +1,5 @@
+'use strict';
+
 run(
   require('blessed'),
   require('child_process'),


### PR DESCRIPTION
Without `'use strict'`, I received this error:

```
% npm start

> rehydrate@0.0.1 start path/to/rehydrate
> node battleStation.js -- bsb -make-world -w

path/to/rehydrate/battleStation.js:13
  let lastCompileTime = null;
  ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:414:25)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:467:10)
    at startup (node.js:136:18)
    at node.js:963:3

npm ERR! Darwin 16.4.0
npm ERR! argv "path/to/.nvm/versions/node/v4.2.3/bin/node" "path/to/.nvm/versions/node/v4.2.3/bin/npm" "start"
npm ERR! node v4.2.3
npm ERR! npm  v2.14.7
npm ERR! code ELIFECYCLE
npm ERR! rehydrate@0.0.1 start: `node battleStation.js -- bsb -make-world -w`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the rehydrate@0.0.1 start script 'node battleStation.js -- bsb -make-world -w'.
npm ERR! This is most likely a problem with the rehydrate package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node battleStation.js -- bsb -make-world -w
npm ERR! You can get their info via:
npm ERR!     npm owner ls rehydrate
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     path/to/rehydrate/npm-debug.log
```