### PR TITLE
use the default bsc-flags behavior

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -6,7 +6,6 @@
   "name" : "rehydrate",
   "version": "0.0.0",
   "ppx-flags": ["reason/reactjs_jsx_ppx.native"],
-  "bsc-flags": ["-w", "-40"],
   "refmt": "reason/refmt_impl.native",
   "bs-dependencies": ["reason-js"],
   "sources": [


### PR DESCRIPTION
we are going to provide a default setting for bsc-flags
see https://github.com/bloomberg/bucklescript/pull/1192 
advanced users can append/reset `bsc-flags`