### PR TITLE
add `ReactRe.listToElement`

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -283,7 +283,7 @@ What can be a `reactElement`?
 - String, but only through `ReactRe.stringToElement myString`.
 - The null element, `ReactRe.nullElement` (BuckleScript's `Js.null` won't work).
 - `array ReactRe.reactElement`, but only through `ReactRe.arrayToElement myArray`.
-- `list ReactRe.reactElement`, but only through `ReactRe.listToElement myList`.
+- `list ReactRe.reactElement`, a helper implemented as `ReactRe.arrayToElement (Array.of_list myList)`
 
 ReactJS children must be typed as `Js.null_undefined ReactRe.reactJsChildren`. They can be converted into a `list ReactRe.reactElement` with `ReactRe.jsChildrenToReason myJSChildren`;
 

--- a/documentation.md
+++ b/documentation.md
@@ -283,6 +283,7 @@ What can be a `reactElement`?
 - String, but only through `ReactRe.stringToElement myString`.
 - The null element, `ReactRe.nullElement` (BuckleScript's `Js.null` won't work).
 - `array ReactRe.reactElement`, but only through `ReactRe.arrayToElement myArray`.
+- `list ReactRe.reactElement`, but only through `ReactRe.listToElement myList`.
 
 ReactJS children must be typed as `Js.null_undefined ReactRe.reactJsChildren`. They can be converted into a `list ReactRe.reactElement` with `ReactRe.jsChildrenToReason myJSChildren`;
 

--- a/src/reactRe.re
+++ b/src/reactRe.re
@@ -30,6 +30,8 @@ external stringToElement : string => reactElement = "%identity";
 
 external arrayToElement : array reactElement => reactElement = "%identity";
 
+let listToElement list => arrayToElement (Array.of_list list);
+
 external refToJsObj : reactRef => Js.t {..} = "%identity";
 
 /* We wrap the props for reason->reason components, as a marker that "these props were passed from another

--- a/src/reactRe.rei
+++ b/src/reactRe.rei
@@ -28,6 +28,8 @@ external stringToElement : string => reactElement = "%identity";
 
 external arrayToElement : array reactElement => reactElement = "%identity";
 
+let listToElement : list reactElement => reactElement;
+
 external refToJsObj : reactRef => Js.t {..} = "%identity";
 
 let jsChildrenToReason: Js.null_undefined reactJsChildren => list reactElement;


### PR DESCRIPTION
Since we have `ReactRe.stringToElement` and `ReactRe.arrayToElement` wouldn't it be nice to also have `ReactRe.listToElement`? 
E.g.
```reason
let list =
  <ul>
    (items |> List.map item |> Array.of_list |> ReactRe.arrayToElement)
  </ul>;
```
would then be just 
```reason
let list =
  <ul>
    (items |> List.map item |> ReactRe.listToElement)
  </ul>;
```

This is just syntatic sugar, but since `list`s are probably more used than `array`s it would be good to have this.