### PR TITLE
[Docs] Fix example code typo

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -267,11 +267,11 @@ let createElement
 In the rare case where the JS component doesn't accept any prop:
 
 ```reason
-/* Note that here it's a binding =, not a function =>. We're currying. See the section on `createElement`.
+/* Note that here it's a binding =, not a function =>. We're currying. See the section on `createElement`. */
 let createElement = 
   ReactRe.wrapPropsShamelessly 
     foo 
-    (Js.Obj.empty ()) /* BuckleScript bindings. Represents the empty `{}` JS object.
+    (Js.Obj.empty ()) /* BuckleScript bindings. Represents the empty `{}` JS object. */
 ```
 
 Usage:


### PR DESCRIPTION
Preceding comment was not closed, causing the entire example to be syntax-highlighted as a comment.