### PR TITLE
Specify the correct type for dangerouslySetInnerHTML

### DIFF
--- a/src/reactDOMRe.re
+++ b/src/reactDOMRe.re
@@ -521,7 +521,7 @@ external props :
   vocab::string? =>
 
   /* react-specific */
-  dangerouslySetInnerHTML::string? =>
+  dangerouslySetInnerHTML::Js.t {. __html: string }? =>
   suppressContentEditableWarning::Js.boolean? =>
 
   unit =>


### PR DESCRIPTION
Now this matches the React spec and I don't have to do some crazy sorcery that @glennsl showed me.

This fixes #75.